### PR TITLE
Adding the option to force the index.js file extension on directory imports

### DIFF
--- a/lib/rules/file-extension-in-import-ts.js
+++ b/lib/rules/file-extension-in-import-ts.js
@@ -1,6 +1,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
+const forceIndexFileImport = require('../util/force-index-file-import');
 const getTryExtensions = require('../util/get-try-extensions');
 const mappingExtensions = require('../util/mapping-extensions');
 const visitImport = require('../util/visit-import');
@@ -14,9 +15,17 @@ const corePackageOverridePattern =
  * @param {string} filePath The path to the original file to check.
  * @returns {string[]} File extensions.
  */
-function getExistingExtensions(filePath) {
+function getExistingExtensions(filePath, extSearchOptions) {
   const basename = path.basename(filePath, path.extname(filePath));
+
   try {
+    const isDirectory = fs.existsSync(filePath) && fs.statSync(filePath).isDirectory();
+
+    if (isDirectory && extSearchOptions.forceIndexFileImport) {
+      // We are forcing index.js file import when importing from a directory
+      return ['/index.js'];
+    }
+
     return fs
       .readdirSync(path.dirname(filePath))
       .filter((filename) => path.basename(filename, path.extname(filename)) === basename)
@@ -34,6 +43,9 @@ module.exports = {
     const defaultStyle = context.options[0] || 'always';
     const overrideStyle = context.options[1] || {};
     const extMapping = overrideStyle.extMapping || mappingExtensions.mappingDefault;
+    const extSearchOptions = {
+      forceIndexFileImport: overrideStyle.forceIndexFileImport || false,
+    };
 
     function verify({ filePath, name, node }) {
       // Ignore if it's not resolved to a file or it's a bare module.
@@ -44,7 +56,7 @@ module.exports = {
       // Get extension.
       const originalExt = path.extname(name);
       const resolvedExt = path.extname(filePath);
-      const existingExts = getExistingExtensions(filePath);
+      const existingExts = getExistingExtensions(filePath, extSearchOptions);
       if (!resolvedExt && existingExts.length !== 1) {
         // Ignore if the file extension could not be determined one.
         return;
@@ -111,6 +123,7 @@ module.exports = {
         },
         properties: {
           extMapping: mappingExtensions.schema,
+          forceIndexFileImport: forceIndexFileImport.schema,
           tryExtensions: getTryExtensions.schema,
         },
         type: 'object',

--- a/lib/util/force-index-file-import.js
+++ b/lib/util/force-index-file-import.js
@@ -1,0 +1,1 @@
+module.exports.schema = { type: 'boolean' };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-file-extension-in-import-ts",
-  "version": "0.9.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-file-extension-in-import-ts",
-      "version": "0.9.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "is-core-module": "^2.9.0",
@@ -2018,9 +2018,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -2856,9 +2856,9 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.10.0.tgz",
-      "integrity": "sha512-2w35xrS5rVtAW0g67LqtxCZN5cdddz/woQRfS0OJXaljXEoTychZ4jnE+CQgra/wX4ZvHeiChTUMenCwfIYEYw==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
+      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
@@ -4702,9 +4702,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -5307,9 +5307,9 @@
       }
     },
     "simple-git": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.10.0.tgz",
-      "integrity": "sha512-2w35xrS5rVtAW0g67LqtxCZN5cdddz/woQRfS0OJXaljXEoTychZ4jnE+CQgra/wX4ZvHeiChTUMenCwfIYEYw==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
+      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-file-extension-in-import-ts",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The plugin check and fix file extensions in Node.js application type module in Typescript",
   "keywords": [],
   "homepage": "https://github.com/AlexSergey/eslint-plugin-file-extension-in-import-ts#readme",


### PR DESCRIPTION
This was tested locally on a personal project.

Open to suggestions if we want to include testing into the plugin.