### PR TITLE
Ignore import type and export type declarations

### DIFF
--- a/lib/util/visit-import.js
+++ b/lib/util/visit-import.js
@@ -38,7 +38,7 @@ module.exports = function visitImport(context, { includeCore = false, optionInde
 
       const name = sourceNode && stripImportPathParams(sourceNode.value);
       // Note: "999" arbitrary to check current/future Node.js version
-      if (name && (includeCore || !isCoreModule(name, '999'))) {
+      if (name && node.importKind !== 'type' && node.exportKind !== 'type' && (includeCore || !isCoreModule(name, '999'))) {
         targets.push(new ImportTarget(sourceNode, name, options));
       }
     },


### PR DESCRIPTION
Skip `import type` and `export type` declarations in the targets.