### PR TITLE
docs: fix usage `extensionsMapping` -> `extMapping`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In this plugin I will add possibility to make mapping for extensions:
 'file-extension-in-import-ts/file-extension-in-import-ts': [
   'error',
   'always',
-  { extMapping: {'.ts': '.js', forceIndexFileImport: true }}
+  { extMapping: {'.ts': '.js' }, forceIndexFileImport: true }
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In this plugin I will add possibility to make mapping for extensions:
 'file-extension-in-import-ts/file-extension-in-import-ts': [
   'error',
   'always',
-  { extensionsMapping: {'.ts': '.js', forceIndexFileImport: true }}
+  { extMapping: {'.ts': '.js', forceIndexFileImport: true }}
 ]
 ```
 


### PR DESCRIPTION
It looks like actual option name is `extMapping`.

https://github.com/AlexSergey/eslint-plugin-file-extension-in-import-ts/blob/54db0028f715fc4e0cef44cc215fa2f36372e8fd/lib/rules/file-extension-in-import-ts.js#L45

## Fixes

- correct `extensionsMapping` -> `extMapping`
- correct `forceIndexFileImport` position